### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "ali-arttemplate": "^3.0.3"
+    "findup-sync": "^0.2.1"
   },
   "devDependencies": {
     "cssmin": "^0.4.3",
@@ -39,7 +39,7 @@
     "grunt-contrib-nodeunit": "^0.3.3"
   },
   "peerDependencies": {
-    "grunt": "~0.4.5"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin"
@@ -48,8 +48,5 @@
   "readmeFilename": "README.md",
   "gitHead": "4f90959b14cdc5769bc70be842a8351d5ea3b408",
   "_id": "grunt-component@0.0.1",
-  "_shasum": "37e0f634b2c026ba36498a3f7903755c7eede11c",
-  "dependencies": {
-    "findup-sync": "^0.2.1"
-  }
+  "_shasum": "37e0f634b2c026ba36498a3f7903755c7eede11c"
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
